### PR TITLE
Refactor functors and related packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Breaking changes:
   - Added support for PureScript 0.14 and dropped support for all previous versions (#15)
 
 New features:
+  - This package no longer depends on the `purescript-contravariant` and `purescript-foldable-traversable` packages. Relevant instances have been moved to those packages. (#19)
 
 Bugfixes:
 

--- a/bower.json
+++ b/bower.json
@@ -21,8 +21,6 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-contravariant": "master",
-    "purescript-foldable-traversable": "master",
     "purescript-invariant": "master",
     "purescript-newtype": "master",
     "purescript-prelude": "master"

--- a/src/Data/Const.purs
+++ b/src/Data/Const.purs
@@ -2,19 +2,10 @@ module Data.Const where
 
 import Prelude
 
-import Data.Bifoldable (class Bifoldable)
-import Data.Bifunctor (class Bifunctor)
-import Data.Bitraversable (class Bitraversable)
 import Data.Eq (class Eq1)
-import Data.Foldable (class Foldable)
-import Data.FoldableWithIndex (class FoldableWithIndex)
-import Data.Functor.Contravariant (class Contravariant)
 import Data.Functor.Invariant (class Invariant, imapF)
-import Data.FunctorWithIndex (class FunctorWithIndex)
 import Data.Newtype (class Newtype)
 import Data.Ord (class Ord1)
-import Data.Traversable (class Traversable)
-import Data.TraversableWithIndex (class TraversableWithIndex)
 
 -- | The `Const` type constructor, which wraps its first type argument
 -- | and ignores its second. That is, `Const a b` is isomorphic to `a`
@@ -62,46 +53,11 @@ derive newtype instance booleanAlgebraConst :: BooleanAlgebra a => BooleanAlgebr
 
 derive instance functorConst :: Functor (Const a)
 
-instance bifunctorConst :: Bifunctor Const where
-  bimap f _ (Const a) = Const (f a)
-
-instance functorWithIndexConst :: FunctorWithIndex Void (Const a) where
-  mapWithIndex _ (Const x) = Const x
-
 instance invariantConst :: Invariant (Const a) where
   imap = imapF
-
-instance contravariantConst :: Contravariant (Const a) where
-  cmap _ (Const x) = Const x
 
 instance applyConst :: Semigroup a => Apply (Const a) where
   apply (Const x) (Const y) = Const (x <> y)
 
 instance applicativeConst :: Monoid a => Applicative (Const a) where
   pure _ = Const mempty
-
-instance foldableConst :: Foldable (Const a) where
-  foldr _ z _ = z
-  foldl _ z _ = z
-  foldMap _ _ = mempty
-
-instance foldableWithIndexConst :: FoldableWithIndex Void (Const a) where
-  foldrWithIndex _ z _ = z
-  foldlWithIndex _ z _ = z
-  foldMapWithIndex _ _ = mempty
-
-instance bifoldableConst :: Bifoldable Const where
-  bifoldr f _ z (Const a) = f a z
-  bifoldl f _ z (Const a) = f z a
-  bifoldMap f _ (Const a) = f a
-
-instance traversableConst :: Traversable (Const a) where
-  traverse _ (Const x) = pure (Const x)
-  sequence (Const x) = pure (Const x)
-
-instance traversableWithIndexConst :: TraversableWithIndex Void (Const a) where
-  traverseWithIndex _ (Const x) = pure (Const x)
-
-instance bitraversableConst :: Bitraversable Const where
-  bitraverse f _ (Const a) = Const <$> f a
-  bisequence (Const a) = Const <$> a


### PR DESCRIPTION
This is part of a set of commits that rearrange the dependencies between
multiple packages. The immediate motivation is to allow certain newtypes
to be reused between `profunctor` and `bifunctors`, but this particular
approach goes a little beyond that in two ways: first, it attempts to
move data types (`either`, `tuple`) toward the bottom of the dependency
stack; and second, it tries to ensure no package comes between
`functors` and the packages most closely related to it, in order to open
the possibility of merging those packages together (which may be
desirable if at some point in the future additional newtypes are added
which reveal new and exciting constraints on the module dependency
graph).

**Description of the change**

See discussion in purescript/purescript-profunctor#23.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
